### PR TITLE
URL encode requested filename

### DIFF
--- a/src/main/java/cpw/mods/forge/serverpacklocator/client/SimpleHttpClient.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/client/SimpleHttpClient.java
@@ -20,9 +20,11 @@ import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -146,7 +148,14 @@ public class SimpleHttpClient {
         channel.attr(HANDLER).set(this::receiveFile);
         LOGGER.debug("Requesting file {}", nextFile);
         LaunchEnvironmentHandler.INSTANCE.addProgressMessage("Requesting file "+nextFile);
-        final DefaultFullHttpRequest fileHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/files/"+nextFile);
+        String encfile = nextFile;
+        try {
+        	encfile = URLEncoder.encode(nextFile, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            // never going to happen
+        }
+        encfile = encfile.replaceAll("\\+","%20");
+        final DefaultFullHttpRequest fileHttpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/files/"+encfile);
         fileHttpRequest.headers().set(HttpHeaderNames.ACCEPT, "application/octet-stream");
         final ChannelFuture channelFuture = channel.writeAndFlush(fileHttpRequest);
         channelFuture.awaitUninterruptibly();

--- a/src/main/java/cpw/mods/forge/serverpacklocator/server/RequestHandler.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/server/RequestHandler.java
@@ -13,6 +13,8 @@ import sun.security.x509.X500Name;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
@@ -39,6 +41,11 @@ class RequestHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
             buildReply(ctx, msg, HttpResponseStatus.OK, "application/json", s);
         } else if (msg.uri().startsWith("/files/")) {
             String fileName = msg.uri().substring(7);
+            try {
+            	fileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8.name());
+            } catch (UnsupportedEncodingException e) {
+                // never going to happen
+            }
             byte[] file = serverSidedPackHandler.getFileManager().findFile(fileName);
             if (file == null) {
                 build404(ctx, msg);


### PR DESCRIPTION
URL encode and decode the request filename on the client and on the server.
This allows filenames to have spaces.