### PR TITLE
Add Oracle Java 8 u241 compatibility

### DIFF
--- a/src/main/java/cpw/mods/forge/serverpacklocator/cert/CertificateManager.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/cert/CertificateManager.java
@@ -138,6 +138,10 @@ public class CertificateManager {
             info.set(X509CertInfo.KEY, new CertificateX509Key(keypair.getPublic()));
             info.set(X509CertInfo.ALGORITHM_ID,
                     new CertificateAlgorithmId(new AlgorithmId(AlgorithmId.sha1WithRSAEncryption_oid)));
+            
+            CertificateExtensions extensions = new CertificateExtensions();
+            extensions.set(BasicConstraintsExtension.NAME, new BasicConstraintsExtension(true, 0));
+            info.set(X509CertInfo.EXTENSIONS, extensions);
 
             // Sign the cert to identify the algorithm that's used.
             cert = new X509CertImpl(info);


### PR DESCRIPTION
With the update u241 for Java 8, Oracle added the requirement for CA certificates to have the `cA field` set to `true` (see change `JDK-8230318`).
Currently the serverpacklocator closes incomming connections with the following error:
`[ServerPack Locator Slave - 3/WARN] [cpw.mods.forge.serverpacklocator.server.RequestHandler/]: Disconnected unauthenticated peer at /<IP>:50084 : PKIX path validation failed: sun.security.validator.ValidatorException: TrustAnchor with subject "CN=<DOMAIN>" is not a CA certificate`
The current workaround is to disable the check by starting the server with the `-Djdk.security.allowNonCaAnchor="true"` flag.

This PR adds a BasicConstraintsExtension to the certificate when generating one.